### PR TITLE
feat(notifications): migrate OneSignal channel to v5 SDK with alias targeting

### DIFF
--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -22,4 +22,4 @@ alsoApplyTo: "src/Traits/**/*.php"
 - Return typed morphMany/morphTo: `MorphMany<NotificationSetting, $this>`
 - HasProfilePhoto: falls back to ui-avatars.com URL using `config('magic-starter.ui_avatars_url')`
 - HasNotifications: `prefers()` returns true by default if notification type not in registry
-- HasNotifications: `routeNotificationForOneSignal()` prefixes user ID with `user_` (OneSignal requires it)
+- HasNotifications: `routeNotificationForOneSignal()` returns `['external_id' => ['user_'.$this->getKey()]]` for OneSignal v5 alias targeting; channel driver is `FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel`

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "^5.0",
         "pragmarx/google2fa": "^8.0|^9.0",
-        "bacon/bacon-qr-code": "^3.0"
+        "bacon/bacon-qr-code": "^3.0",
+        "onesignal/onesignal-php-api": "^5.3"
     },
     "suggest": {
         "geoip2/geoip2": "Optional: for IP geolocation in session management"

--- a/config/magic-starter.php
+++ b/config/magic-starter.php
@@ -42,6 +42,7 @@ return [
         // \FlutterSdk\MagicStarter\Features::newsletterSubscription(),
         // \FlutterSdk\MagicStarter\Features::extendedProfile(),
         // \FlutterSdk\MagicStarter\Features::notifications(),
+        // \FlutterSdk\MagicStarter\Features::onesignal(),
         // \FlutterSdk\MagicStarter\Features::guestAuth(),
         // \FlutterSdk\MagicStarter\Features::phoneOtp(),
         // \FlutterSdk\MagicStarter\Features::emailVerification(),
@@ -245,5 +246,53 @@ return [
         */
 
         'challenge_token_ttl' => 5,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | OneSignal Push Notifications
+    |--------------------------------------------------------------------------
+    |
+    | Configure the settings for OneSignal push notifications. This includes
+    | the app ID, REST API key, and the default target channel for push messages.
+    |
+    */
+
+    'onesignal' => [
+        /*
+        |--------------------------------------------------------------------------
+        | OneSignal App ID
+        |--------------------------------------------------------------------------
+        |
+        | The OneSignal application ID for your project. Required to send push
+        | notifications via the OneSignal PHP SDK.
+        |
+        */
+
+        'app_id' => env('ONESIGNAL_APP_ID'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | OneSignal REST API Key
+        |--------------------------------------------------------------------------
+        |
+        | The OneSignal REST API key for server-to-server authentication.
+        | Required to send push notifications via the OneSignal PHP SDK.
+        |
+        */
+
+        'rest_api_key' => env('ONESIGNAL_REST_API_KEY'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | OneSignal Target Channel
+        |--------------------------------------------------------------------------
+        |
+        | The default delivery channel for OneSignal push notifications.
+        | Typically 'push' for native mobile push notifications.
+        |
+        */
+
+        'target_channel' => 'push',
     ],
 ];

--- a/doc/architecture/models.md
+++ b/doc/architecture/models.md
@@ -365,7 +365,7 @@ Resolution order:
 
 **`notificationPreferenceMatrix(): array`** — returns the full preference state for all registered notification types. DB overrides use slug-based keys (not FQCNs) to ensure a stable API response shape regardless of how types were registered.
 
-**`routeNotificationForOneSignal(): array`** — returns `['include_external_user_ids' => ['user_' . $this->id]]`. The `user_` prefix is required because OneSignal rejects simple numeric values such as `0` or `1` as external IDs. The format must match `Notify.initializePush('user_' + user.id)` in the Flutter app.
+**`routeNotificationForOneSignal(): array`**: returns `['external_id' => ['user_' . $this->getKey()]]` for v5 SDK alias-based routing. The payload is passed to `FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel`, which applies the aliases to the notification via `setIncludeAliases()`. The `user_` prefix is required because OneSignal rejects simple numeric values such as `0` or `1` as external IDs. The format must match `Notify.initializePush('user_' + user.id)` in the Flutter app.
 
 ### <a name="twofactorauthenticatable"></a>TwoFactorAuthenticatable
 

--- a/doc/basics/notifications.md
+++ b/doc/basics/notifications.md
@@ -14,6 +14,7 @@
 - [HasNotifications Trait](#hasnotifications-trait)
   - [prefers()](#prefers)
   - [routeNotificationForOneSignal()](#routenotificationforonesignal)
+- [OneSignal Push Channel (v5 SDK)](#onesignal-push-channel)
 - [NotificationSetting Model](#notificationsetting-model)
 - [Channel Gating via GateNotificationChannels](#channel-gating-via-gatenotificationchannels)
 - [NotificationPreferenceRegistry](#notificationpreferenceregistry)
@@ -309,14 +310,14 @@ This method is called by `GateNotificationChannels` during the `NotificationSend
 public function routeNotificationForOneSignal(): array
 {
     return [
-        'include_external_user_ids' => ['user_' . $this->id],
+        'external_id' => ['user_' . $this->getKey()],
     ];
 }
 ```
 
-Returns the routing payload for the OneSignal notification channel. The `user_` prefix is **required** because OneSignal rejects bare numeric strings like `'0'`, `'1'`, or `'-1'` as external IDs.
+Returns the routing payload for the OneSignal v5 notification channel using alias-based targeting. The `external_id` key maps to an array of alias identifiers that will be passed to the OneSignal SDK's `setIncludeAliases()` method by the package's `FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel` driver.
 
-The format must match the external ID registered by the Flutter client:
+The `user_` prefix is **required** because OneSignal rejects bare numeric strings like `'0'`, `'1'`, or `'-1'` as external IDs. The format must match the external ID registered by the Flutter client:
 
 ```dart
 Notify.initializePush('user_' + user.id);
@@ -328,10 +329,69 @@ To use a different format, override this method in your User model:
 public function routeNotificationForOneSignal(): array
 {
     return [
-        'include_external_user_ids' => ['app_user_' . $this->uuid],
+        'external_id' => ['app_user_' . $this->uuid],
     ];
 }
 ```
+
+---
+
+## <a name="onesignal-push-channel"></a>OneSignal Push Channel (v5 SDK)
+
+The package ships `FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel`, a Laravel notification channel driver backed by the official `onesignal/onesignal-php-api: ^5.3` SDK.
+
+### Configuration
+
+Enable the feature by adding to your application:
+
+```php
+// config/magic-starter.php
+'features' => [
+    Features::onesignal(),
+],
+```
+
+When enabled, the service provider automatically registers the `onesignal` driver on Laravel's `ChannelManager` and registers the logical alias `push => onesignal` in `NotificationPreferenceRegistry`.
+
+Required configuration keys under `magic-starter.onesignal`:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `app_id` | string | OneSignal Application ID |
+| `rest_api_key` | string | OneSignal REST API key. Falls back to `services.onesignal.rest_api_key` if not set. |
+| `target_channel` | string | Default notification channel. Defaults to `'push'`. |
+
+### Notification Contract
+
+Any notification class that sends via OneSignal must implement the `toOneSignal()` method:
+
+```php
+use \onesignal\client\model\Notification;
+
+public function toOneSignal(mixed $notifiable): Notification
+{
+    return new Notification(
+        app_id: config('magic-starter.onesignal.app_id'),
+    )
+        ->setHeadings(
+            new \onesignal\client\model\LanguageStringMap(
+                'en' => 'Order Update'
+            )
+        )
+        ->setContents(
+            new \onesignal\client\model\LanguageStringMap(
+                'en' => 'Your order #12345 has shipped.'
+            )
+        );
+}
+```
+
+The driver handles the remaining setup:
+
+- **`app_id`** is always overridden from `config('magic-starter.onesignal.app_id')`.
+- **Aliases** and **`target_channel`** from the notifiable's `routeNotificationForOneSignal()` are applied only when the notification payload has none set. This allows per-notification customization while preserving sensible defaults.
+
+The channel passes the `Notification` instance directly to the OneSignal SDK for delivery.
 
 ---
 

--- a/resources/boost/skills/magic-starter-development/references/models-and-migrations.md
+++ b/resources/boost/skills/magic-starter-development/references/models-and-migrations.md
@@ -22,7 +22,7 @@ Relations never reference App\Models\* directly. All model classes are resolved 
 
 HasProfilePhoto exposes getProfilePhotoUrlAttribute(), resolving the configured disk URL when profile_photo_path is set, falling back to a ui-avatars.com URL built from name initials. The ui_avatars_url config key controls the base URL.
 
-HasNotifications provides morphMany notificationSettings() returning MorphMany<NotificationSetting, $this>, a prefers() method with a 3-step fallback (registry miss defaults to true, DB override wins, then registry default channels), and routeNotificationForOneSignal() prefixing IDs with user_ for OneSignal compatibility.
+HasNotifications provides morphMany notificationSettings() returning MorphMany<NotificationSetting, $this>, a prefers() method with a 3-step fallback (registry miss defaults to true, DB override wins, then registry default channels), and routeNotificationForOneSignal() returning ['external_id' => ['user_' . $this->getKey()]] for OneSignal v5 alias targeting via OneSignalChannel driver.
 
 HasTeams provides ownedTeams(), teams() (with pivot), allTeams() (merge + sort), currentTeam() BelongsTo, getCurrentTeamOrPersonal(), belongsToTeam(), ownsTeam(), and hasTeamRole() reading pivot->role.
 

--- a/resources/boost/skills/magic-starter-development/references/notifications.md
+++ b/resources/boost/skills/magic-starter-development/references/notifications.md
@@ -35,10 +35,11 @@
 - Enabled state respects DB overrides; falls back to registry default if no override.
 - Locked channels cannot be toggled (UI should disable them); locked() call on registry returns list of unchangeable channels per type.
 
-### OneSignal routing requires 'user_' prefix on external_id
+### OneSignal routing uses alias-based targeting with v5 SDK
 
-- routeNotificationForOneSignal() returns array with include_external_user_ids key set to ['user_' . $this->id].
-- The prefix is required because OneSignal blocks simple numeric IDs as external_id; must match app-side call Notify.initializePush('user_' + user.id).
+- routeNotificationForOneSignal() returns ['external_id' => ['user_' . $this->getKey()]] for OneSignal v5 alias targeting.
+- The prefix is required because OneSignal rejects bare numeric IDs as external_id; must match app-side call Notify.initializePush('user_' + user.id).
+- Channel driver is FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel; notification returned map is passed to \onesignal\client\model\Notification::setIncludeAliases().
 
 ### Consumer pattern: register types, let GateNotificationChannels filter
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -66,6 +66,14 @@ class Features
     }
 
     /**
+     * Enable the OneSignal push notification feature.
+     */
+    public static function onesignal(): string
+    {
+        return 'onesignal';
+    }
+
+    /**
      * Enable the two-factor authentication feature.
      */
     public static function twoFactorAuthentication(): string
@@ -167,6 +175,14 @@ class Features
     public static function hasNotificationFeatures(): bool
     {
         return static::enabled(static::notifications());
+    }
+
+    /**
+     * Determine whether the OneSignal push notification feature is enabled.
+     */
+    public static function hasOnesignalFeatures(): bool
+    {
+        return static::enabled(static::onesignal());
     }
 
     /**

--- a/src/MagicStarterServiceProvider.php
+++ b/src/MagicStarterServiceProvider.php
@@ -66,7 +66,7 @@ class MagicStarterServiceProvider extends ServiceProvider
 
             if ($restApiKey === null || $restApiKey === '') {
                 throw new \RuntimeException(
-                    'OneSignal REST API key missing. Set ONESIGNAL_REST_API_KEY or services.onesignal.rest_api_key.',
+                    'OneSignal REST API key missing. Set ONESIGNAL_REST_API_KEY, magic-starter.onesignal.rest_api_key, or services.onesignal.rest_api_key.',
                 );
             }
 

--- a/src/MagicStarterServiceProvider.php
+++ b/src/MagicStarterServiceProvider.php
@@ -58,6 +58,23 @@ class MagicStarterServiceProvider extends ServiceProvider
         $this->app->bind(Contracts\ConfirmsTwoFactorAuthentication::class, Actions\ConfirmTwoFactorAuthentication::class);
         $this->app->bind(Contracts\DisablesTwoFactorAuthentication::class, Actions\DisableTwoFactorAuthentication::class);
         $this->app->bind(Contracts\GeneratesNewRecoveryCodes::class, Actions\GenerateNewRecoveryCodes::class);
+
+        // OneSignal SDK client singleton (resolved lazily, only when injected).
+        $this->app->singleton(\onesignal\client\api\DefaultApi::class, function (): \onesignal\client\api\DefaultApi {
+            $restApiKey = config('magic-starter.onesignal.rest_api_key')
+                ?? config('services.onesignal.rest_api_key');
+
+            if ($restApiKey === null || $restApiKey === '') {
+                throw new \RuntimeException(
+                    'OneSignal REST API key missing. Set ONESIGNAL_REST_API_KEY or services.onesignal.rest_api_key.',
+                );
+            }
+
+            $config = \onesignal\client\Configuration::getDefaultConfiguration()
+                ->setRestApiKeyToken((string) $restApiKey);
+
+            return new \onesignal\client\api\DefaultApi(new \GuzzleHttp\Client, $config);
+        });
     }
 
     /**
@@ -103,6 +120,16 @@ class MagicStarterServiceProvider extends ServiceProvider
                 NotificationSending::class,
                 Listeners\GateNotificationChannels::class,
             );
+        }
+
+        // 3.6. Register OneSignal push channel when onesignal feature is enabled.
+        if (Features::hasOnesignalFeatures()) {
+            $this->app->make(\Illuminate\Notifications\ChannelManager::class)
+                ->extend('onesignal', fn ($app) => $app->make(
+                    \FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel::class,
+                ));
+
+            NotificationPreferenceRegistry::channelAliases(['push' => 'onesignal']);
         }
 
         // 3.7. Register package translations.

--- a/src/Notifications/Channels/OneSignalChannel.php
+++ b/src/Notifications/Channels/OneSignalChannel.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace FlutterSdk\MagicStarter\Notifications\Channels;
+
+use Illuminate\Notifications\Notification;
+use InvalidArgumentException;
+use onesignal\client\api\DefaultApi;
+use onesignal\client\model\CreateNotificationSuccessResponse;
+use onesignal\client\model\Notification as OneSignalNotification;
+use Throwable;
+
+/**
+ * OneSignal push notification channel using the official v5 PHP SDK.
+ *
+ * This channel sends push notifications via alias-based targeting. The OneSignal v5 API
+ * uses "aliases" (e.g. external_id, onesignal_id) to identify recipients instead of
+ * legacy player IDs. When no explicit aliases or segments are set on the notification
+ * payload, this channel automatically resolves aliases from the notifiable entity.
+ *
+ * Notification classes that wish to use this channel must implement a `toOneSignal()`
+ * method returning an `\onesignal\client\model\Notification` instance:
+ *
+ *     public function toOneSignal(mixed $notifiable): \onesignal\client\model\Notification
+ *
+ * The `app_id` is always forced from package config (`magic-starter.onesignal.app_id`),
+ * regardless of what the notification sets.
+ */
+class OneSignalChannel
+{
+    public function __construct(
+        private DefaultApi $client,
+    ) {}
+
+    /**
+     * Send the given notification via OneSignal.
+     *
+     *
+     * @return CreateNotificationSuccessResponse<int|null, mixed>|null
+     *
+     * @throws InvalidArgumentException When toOneSignal() returns an unexpected type.
+     * @throws Throwable Re-thrown after reporting when the API call fails.
+     */
+    public function send(mixed $notifiable, Notification $notification): ?CreateNotificationSuccessResponse
+    {
+        // 1. Skip if the notification does not support OneSignal
+        if (! method_exists($notification, 'toOneSignal')) {
+            return null;
+        }
+
+        // 2. Resolve aliases from the notifiable
+        /** @var array<string, array<int, string>> $aliases */
+        $aliases = method_exists($notifiable, 'routeNotificationForOneSignal')
+            ? $notifiable->routeNotificationForOneSignal()
+            : ['external_id' => [(string) $notifiable->getKey()]];
+
+        // 3. Build the OneSignal notification payload (toOneSignal is user-defined per Notification class)
+        $payload = \call_user_func([$notification, 'toOneSignal'], $notifiable);
+
+        if (! $payload instanceof OneSignalNotification) {
+            throw new InvalidArgumentException(sprintf(
+                '%s::toOneSignal() must return %s; got %s.',
+                get_class($notification),
+                OneSignalNotification::class,
+                get_debug_type($payload),
+            ));
+        }
+
+        // 4. Apply default aliases and target channel when none are explicitly set
+        if ($payload->getIncludeAliases() === null && $payload->getIncludedSegments() === null) {
+            $payload->setIncludeAliases($aliases);
+            $payload->setTargetChannel((string) config('magic-starter.onesignal.target_channel', 'push'));
+        }
+
+        // 5. Always force app_id from package config
+        $payload->setAppId((string) config('magic-starter.onesignal.app_id'));
+
+        // 6. Send via the OneSignal API
+        try {
+            return $this->client->createNotification($payload);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            throw $exception;
+        }
+    }
+}

--- a/src/Notifications/Channels/OneSignalChannel.php
+++ b/src/Notifications/Channels/OneSignalChannel.php
@@ -43,15 +43,22 @@ class OneSignalChannel
     public function send(mixed $notifiable, Notification $notification): ?CreateNotificationSuccessResponse
     {
         // 1. Skip if the notification does not support OneSignal
-        if (! method_exists($notification, 'toOneSignal')) {
+        if (! is_callable([$notification, 'toOneSignal'])) {
             return null;
         }
 
         // 2. Resolve aliases from the notifiable
-        /** @var array<string, array<int, string>> $aliases */
-        $aliases = method_exists($notifiable, 'routeNotificationForOneSignal')
-            ? $notifiable->routeNotificationForOneSignal()
-            : ['external_id' => [(string) $notifiable->getKey()]];
+        if (method_exists($notifiable, 'routeNotificationForOneSignal')) {
+            /** @var array<string, array<int, string>> $aliases */
+            $aliases = $notifiable->routeNotificationForOneSignal();
+        } elseif (method_exists($notifiable, 'getKey')) {
+            $aliases = ['external_id' => [(string) $notifiable->getKey()]];
+        } else {
+            throw new InvalidArgumentException(sprintf(
+                '%s must implement routeNotificationForOneSignal() or getKey() to receive OneSignal notifications.',
+                get_debug_type($notifiable),
+            ));
+        }
 
         // 3. Build the OneSignal notification payload (toOneSignal is user-defined per Notification class)
         $payload = \call_user_func([$notification, 'toOneSignal'], $notifiable);
@@ -71,8 +78,16 @@ class OneSignalChannel
             $payload->setTargetChannel((string) config('magic-starter.onesignal.target_channel', 'push'));
         }
 
-        // 5. Always force app_id from package config
-        $payload->setAppId((string) config('magic-starter.onesignal.app_id'));
+        // 5. Always force app_id from package config (validated non-empty)
+        $appId = config('magic-starter.onesignal.app_id');
+
+        if (! is_string($appId) || trim($appId) === '') {
+            throw new InvalidArgumentException(
+                'The OneSignal app ID configuration value [magic-starter.onesignal.app_id] must be a non-empty string.',
+            );
+        }
+
+        $payload->setAppId($appId);
 
         // 6. Send via the OneSignal API
         try {

--- a/src/Traits/HasNotifications.php
+++ b/src/Traits/HasNotifications.php
@@ -109,23 +109,36 @@ trait HasNotifications
     }
 
     /**
-     * Route notifications for the OneSignal channel.
+     * Route notifications for the OneSignal channel (SDK v5 alias targeting).
      *
-     * Returns the external user ID that OneSignal uses to target this user.
-     * The `user_` prefix is required because OneSignal blocks simple values
-     * like '0', '1', '-1' as external_id.
+     * Returns an alias map that `OneSignalChannel` passes to
+     * `\onesignal\client\model\Notification::setIncludeAliases()`.
+     * The outer key is the alias label ('external_id') and the value is an
+     * array of alias values to target.
      *
-     * The format must match what the Flutter app sets when calling
-     * `Notify.initializePush('user_' + user.id)`.
+     * The `user_` prefix is required for two reasons:
+     *   - OneSignal rejects bare numeric values such as '0', '1', '-1' as
+     *     alias values.
+     *   - The Flutter client registers the same prefixed id via
+     *     `Notify.initializePush('user_' + user.id)`, so both sides must
+     *     agree on the format.
      *
-     * Override this method in your User model if you need a different format.
+     * `getKey()` is used instead of `$this->id` so the method works correctly
+     * for both integer and UUID primary keys.
      *
-     * @return array<string, mixed>
+     * Override in your User model to change the alias label or value format:
+     *
+     *   public function routeNotificationForOneSignal(): array
+     *   {
+     *       return ['external_id' => ['app_user_' . $this->uuid]];
+     *   }
+     *
+     * @return array<string, array<int, string>>
      */
     public function routeNotificationForOneSignal(): array
     {
         return [
-            'include_external_user_ids' => ['user_' . $this->id],
+            'external_id' => ['user_' . $this->getKey()],
         ];
     }
 }

--- a/tests/Notifications/Channels/OneSignalChannelTest.php
+++ b/tests/Notifications/Channels/OneSignalChannelTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace FlutterSdk\MagicStarter\Tests\Notifications\Channels;
+
+use FlutterSdk\MagicStarter\Notifications\Channels\OneSignalChannel;
+use FlutterSdk\MagicStarter\Tests\TestCase;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use onesignal\client\api\DefaultApi;
+use onesignal\client\model\Notification as OneSignalNotification;
+use RuntimeException;
+
+final class OneSignalChannelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['magic-starter.onesignal.app_id' => 'test-app-id']);
+        config(['magic-starter.onesignal.target_channel' => 'push']);
+    }
+
+    public function test_send_invokes_create_notification_with_notification_payload(): void
+    {
+        // Arrange
+        $capturedPayload = null;
+        $client = $this->createMock(DefaultApi::class);
+        $client->expects($this->once())
+            ->method('createNotification')
+            ->willReturnCallback(function (OneSignalNotification $payload) use (&$capturedPayload): null {
+                $capturedPayload = $payload;
+
+                return null;
+            });
+
+        $notification = new StubOneSignalNotification;
+        $notifiable = new StubRoutableNotifiable('alpha');
+
+        $channel = new OneSignalChannel($client);
+
+        // Act
+        $channel->send($notifiable, $notification);
+
+        // Assert
+        $this->assertSame($notification->toOneSignal($notifiable), $capturedPayload);
+        $this->assertSame('test-app-id', $capturedPayload->getAppId());
+        $this->assertSame('push', $capturedPayload->getTargetChannel());
+        $this->assertSame(['external_id' => ['custom_alpha']], $capturedPayload->getIncludeAliases());
+    }
+
+    public function test_send_forces_app_id_from_config(): void
+    {
+        // Arrange
+        $capturedPayload = null;
+        $client = $this->createMock(DefaultApi::class);
+        $client->expects($this->once())
+            ->method('createNotification')
+            ->willReturnCallback(function (OneSignalNotification $payload) use (&$capturedPayload): null {
+                $capturedPayload = $payload;
+
+                return null;
+            });
+
+        $seededPayload = new OneSignalNotification;
+        $seededPayload->setAppId('user-set-wrong-id');
+
+        $notification = new StubOneSignalNotification($seededPayload);
+        $notifiable = new StubRoutableNotifiable('beta');
+
+        $channel = new OneSignalChannel($client);
+
+        // Act
+        $channel->send($notifiable, $notification);
+
+        // Assert
+        $this->assertSame('test-app-id', $capturedPayload->getAppId());
+    }
+
+    public function test_send_applies_aliases_from_notifiable_when_notification_has_none(): void
+    {
+        // Arrange
+        $capturedPayload = null;
+        $client = $this->createMock(DefaultApi::class);
+        $client->expects($this->once())
+            ->method('createNotification')
+            ->willReturnCallback(function (OneSignalNotification $payload) use (&$capturedPayload): null {
+                $capturedPayload = $payload;
+
+                return null;
+            });
+
+        $notification = new StubOneSignalNotification;
+        $notifiable = new StubRoutableNotifiable('42');
+
+        $channel = new OneSignalChannel($client);
+
+        // Act
+        $channel->send($notifiable, $notification);
+
+        // Assert
+        $this->assertSame(['external_id' => ['custom_42']], $capturedPayload->getIncludeAliases());
+        $this->assertSame('push', $capturedPayload->getTargetChannel());
+    }
+
+    public function test_send_falls_back_to_getkey_when_notifiable_has_no_router(): void
+    {
+        // Arrange
+        $capturedPayload = null;
+        $client = $this->createMock(DefaultApi::class);
+        $client->expects($this->once())
+            ->method('createNotification')
+            ->willReturnCallback(function (OneSignalNotification $payload) use (&$capturedPayload): null {
+                $capturedPayload = $payload;
+
+                return null;
+            });
+
+        $notification = new StubOneSignalNotification;
+        $notifiable = new StubBasicNotifiable('777');
+
+        $channel = new OneSignalChannel($client);
+
+        // Act
+        $channel->send($notifiable, $notification);
+
+        // Assert
+        $this->assertSame(['external_id' => ['777']], $capturedPayload->getIncludeAliases());
+    }
+
+    public function test_send_returns_null_when_notification_lacks_toonesignal(): void
+    {
+        // Arrange
+        $client = $this->createMock(DefaultApi::class);
+        $client->expects($this->never())->method('createNotification');
+
+        $notification = new StubPlainNotification;
+        $notifiable = new StubBasicNotifiable('999');
+
+        $channel = new OneSignalChannel($client);
+
+        // Act
+        $result = $channel->send($notifiable, $notification);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_send_reports_and_rethrows_on_sdk_exception(): void
+    {
+        // Arrange
+        $client = $this->createMock(DefaultApi::class);
+        $client->method('createNotification')->willThrowException(new RuntimeException('boom'));
+
+        $handlerMock = $this->createMock(ExceptionHandler::class);
+        $handlerMock->expects($this->once())
+            ->method('report')
+            ->with($this->isInstanceOf(RuntimeException::class));
+
+        $this->app->instance(ExceptionHandler::class, $handlerMock);
+
+        $notification = new StubOneSignalNotification;
+        $notifiable = new StubBasicNotifiable('1');
+
+        $channel = new OneSignalChannel($client);
+
+        // Assert + Act
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $channel->send($notifiable, $notification);
+    }
+}
+
+class StubOneSignalNotification extends \Illuminate\Notifications\Notification
+{
+    public ?OneSignalNotification $payload;
+
+    public function __construct(?OneSignalNotification $payload = null)
+    {
+        $this->payload = $payload;
+    }
+
+    public function toOneSignal(mixed $notifiable): OneSignalNotification
+    {
+        return $this->payload ??= new OneSignalNotification;
+    }
+}
+
+class StubPlainNotification extends \Illuminate\Notifications\Notification {}
+
+class StubRoutableNotifiable
+{
+    public function __construct(private string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function routeNotificationForOneSignal(): array
+    {
+        return ['external_id' => ['custom_' . $this->key]];
+    }
+}
+
+class StubBasicNotifiable
+{
+    public function __construct(private string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}

--- a/tests/Traits/HasNotificationsTest.php
+++ b/tests/Traits/HasNotificationsTest.php
@@ -312,7 +312,7 @@ final class HasNotificationsTest extends TestCase
         $this->assertTrue($matrix['monitor_down']['channels']['database']['enabled']);
     }
 
-    public function test_route_notification_for_onesignal_returns_external_user_ids(): void
+    public function test_route_notification_for_onesignal_returns_alias_payload(): void
     {
         $user = HasNotifPrefsTestUser::query()->create([
             'name' => 'OneSignal User',
@@ -322,8 +322,8 @@ final class HasNotificationsTest extends TestCase
         $routing = $user->routeNotificationForOneSignal();
 
         $this->assertIsArray($routing);
-        $this->assertArrayHasKey('include_external_user_ids', $routing);
-        $this->assertEquals(['user_' . $user->id], $routing['include_external_user_ids']);
+        $this->assertArrayHasKey('external_id', $routing);
+        $this->assertSame(['user_' . $user->getKey()], $routing['external_id']);
     }
 
     public function test_route_notification_for_onesignal_returns_prefixed_string_id(): void
@@ -335,8 +335,8 @@ final class HasNotificationsTest extends TestCase
 
         $routing = $user->routeNotificationForOneSignal();
 
-        $this->assertIsString($routing['include_external_user_ids'][0]);
-        $this->assertStringStartsWith('user_', $routing['include_external_user_ids'][0]);
+        $this->assertIsString($routing['external_id'][0]);
+        $this->assertStringStartsWith('user_', $routing['external_id'][0]);
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace legacy v4 routing (`include_external_user_ids`) with v5 alias-based targeting using the official `onesignal/onesignal-php-api` SDK.
- Ship a first-party `OneSignalChannel` driver behind the new `onesignal` feature flag, with `DefaultApi` singleton binding and `push => onesignal` channel alias.
- Update `HasNotifications::routeNotificationForOneSignal()` to return the v5 `external_id` alias map (prefixed with `user_`).

## Changes
- Require `onesignal/onesignal-php-api: ^5.3`
- Add `Features::onesignal()` + `hasOnesignalFeatures()`
- Add `src/Notifications/Channels/OneSignalChannel.php` with alias resolution, `toOneSignal()` type check, app_id force-override, and `report()`+rethrow on SDK failure
- Register `DefaultApi` singleton with `services.onesignal` fallback and feature-gate channel extension
- Rewrite HasNotifications tests + add 6 OneSignalChannel unit tests
- Update docs (notifications.md, architecture/models.md), boost skill references, and `.claude/rules/models.md`

Closes #3

## Test plan
- [x] `composer test` — 537 tests, 1462 assertions pass
- [x] `composer analyse` — PHPStan level 6 clean
- [x] `composer lint` — Pint clean
- [ ] Verify in a consuming app: enable `onesignal` feature, send a notification with `toOneSignal()`, confirm v5 payload delivery