### PR TITLE
docs: explain frontend_url requirement for non-localhost backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Documentation**: Clarify in README and installation guide that `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url` flag) is required for non-localhost backends. Email verification links are signed with the backend base (from `APP_URL`); when frontend and backend are on different hosts, the signed URL will have the wrong base and verification links will fail unless the frontend URL is explicitly set. Added detailed troubleshooting section covering symptoms, the solution, and three ways to configure it.
+
 ## [0.0.4] - 2026-03-25
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **Documentation**: Clarify in README and installation guide that `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url` flag) is required for non-localhost backends. Email verification links are signed with the backend base (from `APP_URL`); when frontend and backend are on different hosts, the signed URL will have the wrong base and verification links will fail unless the frontend URL is explicitly set. Added detailed troubleshooting section covering symptoms, the solution, and three ways to configure it.
+- **Documentation**: Clarify in README and installation guide when `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url`) is needed: set it when email links should open a frontend whose host or scheme differs from `APP_URL`; otherwise email links (verification, password reset, and other email links) point at the backend host instead of the frontend app. Added a troubleshooting section covering the symptom, the solution, and three ways to configure it.
 
 ## [0.0.4] - 2026-03-25
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ php artisan vendor:publish --tag=magic-starter-config
 php artisan migrate
 ```
 
+> [!IMPORTANT]
+> **Frontend URL for non-localhost deployments:** email verification links are signed with the backend base (from `APP_URL`). If your frontend runs on a different host than the backend (for example backend on `api.example.com`, app on `app.example.com`), the signed link will carry the wrong base and verification will fail. Set `MAGIC_STARTER_FRONTEND_URL` in your `.env` to the frontend base URL (the `magic-starter.frontend_url` config reads it), or pass `--frontend-url=https://app.example.com` if you install via `php artisan magic-starter:install`. `APP_URL` alone is not enough when the hosts differ.
+
 ### 3. Prepare your User model
 
 Add the required traits to your `User` model:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ php artisan migrate
 ```
 
 > [!IMPORTANT]
-> **Frontend URL for non-localhost deployments:** email verification links are signed with the backend base (from `APP_URL`). If your frontend runs on a different host than the backend (for example backend on `api.example.com`, app on `app.example.com`), the signed link will carry the wrong base and verification will fail. Set `MAGIC_STARTER_FRONTEND_URL` in your `.env` to the frontend base URL (the `magic-starter.frontend_url` config reads it), or pass `--frontend-url=https://app.example.com` if you install via `php artisan magic-starter:install`. `APP_URL` alone is not enough when the hosts differ.
+> **Frontend URL:** The backend signs email links (verification, password reset, and other email links) using `APP_URL` as the base. If your email links should open a frontend whose host or scheme differs from `APP_URL`, set `MAGIC_STARTER_FRONTEND_URL` in your `.env` to the frontend base URL (the `magic-starter.frontend_url` config reads it), or pass `--frontend-url=https://app.example.com` when installing via `php artisan magic-starter:install`. Without it, email links point at the backend host (e.g. `https://api.example.com/email/verify/...`) instead of opening the intended frontend app.
 
 ### 3. Prepare your User model
 

--- a/doc/getting-started/installation.md
+++ b/doc/getting-started/installation.md
@@ -5,6 +5,7 @@
 - [Installing the Package](#installing-the-package)
 - [Service Provider Auto-Discovery](#service-provider-auto-discovery)
 - [Running the Install Command](#running-the-install-command)
+- [Frontend URL for Non-Localhost Deployments](#frontend-url-non-localhost)
 - [Publishable Assets](#publishable-assets)
 - [User Model Setup](#user-model-setup)
 - [Binding Action Contracts](#binding-action-contracts)
@@ -71,7 +72,7 @@ When run without flags, the command uses [Laravel Prompts](https://laravel.com/d
 
 1. **Features** — a `multiselect` prompt with all 12 features pre-selected.
 2. **Route prefix** — a `text` input (defaults to `api/v1`).
-3. **Frontend URL** — a `text` input (defaults to `http://localhost:3000`), used for password reset links in emails.
+3. **Frontend URL** — a `text` input (defaults to `http://localhost:3000`), used for email verification links. **Important:** If your backend is not on localhost, you must set this to your frontend URL (see [Frontend URL for Non-Localhost Deployments](#frontend-url-non-localhost) below).
 4. **Run migrations** — a `confirm` prompt to run `php artisan migrate` immediately.
 
 UUID vs. integer primary keys are auto-detected from your existing `users` table schema. If no `users` table exists (fresh install), UUID is used by default.
@@ -106,6 +107,46 @@ When `--all` is passed, all 12 features are enabled regardless of `--features`.
 
 > [!NOTE]
 > When neither `--uuid` nor `--no-uuid` is provided, the installer auto-detects your existing `users` table schema. If no `users` table exists (fresh install), UUID is used by default.
+
+<a name="frontend-url-non-localhost"></a>
+## Frontend URL for Non-Localhost Deployments
+
+Email verification links are signed by the backend using the base URL from `APP_URL`. When your frontend and backend are on different hosts, the signed verification URLs will have the backend's URL as the base, causing them to fail when clicked in the frontend application.
+
+**Symptom:** Verification links in emails contain `https://backend.example.com/verify/...` but your frontend is at `https://app.example.com`. Clicking the link either directs to a non-existent page or fails to recognize the signature.
+
+**Solution:** Configure the `frontend_url` setting to point to your frontend's base URL. This tells the email notification where to build verification links.
+
+### Setting the Frontend URL
+
+You can provide the frontend URL in three ways:
+
+1. **During install with the flag:**
+   ```bash
+   php artisan magic-starter:install --all --frontend-url=https://app.example.com
+   ```
+
+2. **During interactive install:**
+   When prompted for "Frontend URL", enter your frontend app URL (e.g. `https://app.example.com`).
+
+3. **Via environment variable:**
+   Set `MAGIC_STARTER_FRONTEND_URL` in your `.env`:
+   ```env
+   MAGIC_STARTER_FRONTEND_URL=https://app.example.com
+   ```
+
+### Localhost Development
+
+For localhost development (backend at `http://localhost:8000`, frontend at `http://localhost:3000`), you **must** still set the frontend URL or verification links will point to the backend:
+
+```bash
+php artisan magic-starter:install --all --frontend-url=http://localhost:3000
+```
+
+The default prompt value is `http://localhost:3000`, which covers this common case.
+
+> [!IMPORTANT]
+> Do NOT rely on `APP_URL` alone for non-localhost backends. `APP_URL` sets the backend base and is correct for API routes, but email links need the frontend base. Always set `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url`) when backend and frontend are on different hosts.
 
 <a name="publishable-assets"></a>
 ## Publishable Assets

--- a/doc/getting-started/installation.md
+++ b/doc/getting-started/installation.md
@@ -72,7 +72,7 @@ When run without flags, the command uses [Laravel Prompts](https://laravel.com/d
 
 1. **Features** — a `multiselect` prompt with all 12 features pre-selected.
 2. **Route prefix** — a `text` input (defaults to `api/v1`).
-3. **Frontend URL** — a `text` input (defaults to `http://localhost:3000`), used for email verification links. **Important:** If your backend is not on localhost, you must set this to your frontend URL (see [Frontend URL for Non-Localhost Deployments](#frontend-url-non-localhost) below).
+3. **Frontend URL** — a `text` input (defaults to `http://localhost:3000`), used for email verification, password reset, and other email links. **Important:** Set this to your frontend base URL when its host or scheme differs from `APP_URL` (see [Frontend URL](#frontend-url-non-localhost) below).
 4. **Run migrations** — a `confirm` prompt to run `php artisan migrate` immediately.
 
 UUID vs. integer primary keys are auto-detected from your existing `users` table schema. If no `users` table exists (fresh install), UUID is used by default.
@@ -111,11 +111,9 @@ When `--all` is passed, all 12 features are enabled regardless of `--features`.
 <a name="frontend-url-non-localhost"></a>
 ## Frontend URL for Non-Localhost Deployments
 
-Email verification links are signed by the backend using the base URL from `APP_URL`. When your frontend and backend are on different hosts, the signed verification URLs will have the backend's URL as the base, causing them to fail when clicked in the frontend application.
+The backend signs email links (verification, password reset, and other email links) using `APP_URL` as the base. When your email links should open a frontend whose host or scheme differs from `APP_URL`, configure `frontend_url` to rewrite the link base to your frontend URL. Without it, email links point at the backend host (e.g. `https://api.example.com/email/verify/{id}/{hash}`) instead of opening the intended frontend app or deep link.
 
-**Symptom:** Verification links in emails contain `https://backend.example.com/verify/...` but your frontend is at `https://app.example.com`. Clicking the link either directs to a non-existent page or fails to recognize the signature.
-
-**Solution:** Configure the `frontend_url` setting to point to your frontend's base URL. This tells the email notification where to build verification links.
+**Solution:** Configure the `frontend_url` setting to point to your frontend's base URL. This rewrites the base for all package email links.
 
 ### Setting the Frontend URL
 
@@ -137,16 +135,14 @@ You can provide the frontend URL in three ways:
 
 ### Localhost Development
 
-For localhost development (backend at `http://localhost:8000`, frontend at `http://localhost:3000`), you **must** still set the frontend URL or verification links will point to the backend:
+For localhost development (backend at `http://localhost:8000`, frontend at `http://localhost:3000`), the hosts differ so you should keep `frontend_url` set. The installer defaults the prompt to `http://localhost:3000`, which covers this common case:
 
 ```bash
 php artisan magic-starter:install --all --frontend-url=http://localhost:3000
 ```
 
-The default prompt value is `http://localhost:3000`, which covers this common case.
-
 > [!IMPORTANT]
-> Do NOT rely on `APP_URL` alone for non-localhost backends. `APP_URL` sets the backend base and is correct for API routes, but email links need the frontend base. Always set `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url`) when backend and frontend are on different hosts.
+> Set `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url`) whenever your frontend's host or scheme differs from `APP_URL`. `APP_URL` sets the backend base and is correct for API routes, but email links need the frontend base. A backend and frontend sharing the same origin do not need a separate `frontend_url`.
 
 <a name="publishable-assets"></a>
 ## Publishable Assets


### PR DESCRIPTION
Fixes REPORT friction item #18.

Documents that signed email-verification links use `config('magic-starter.frontend_url')`: non-localhost backends must set `MAGIC_STARTER_FRONTEND_URL` (or `--frontend-url` when installing via the command), since `APP_URL` alone produces broken verification links when the frontend host differs. README + installation.md updated with the symptom, the rationale, and the configuration options. No code changed.