### PR TITLE
fix: persist team switch and stop silently skipping the User model stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **User model stub silently skipped on a fresh app**: `magic-starter:install` published the trait-laden `app/Models/User.php` stub via `vendor:publish` without `--force`, which silently skips an existing target. On a fresh Laravel app (which ships `app/Models/User.php`), the default model was kept with none of the Magic Starter traits (`HasTeams`, `TwoFactorAuthenticatable`, etc.) while the installer still printed "DONE", leaving teams/2FA/profile endpoints broken with no warning. The installer now mirrors the default-users-migration heuristic: it overwrites the stock Laravel default model (or with `--force`), preserves an already trait-equipped or customized model, and prints `SKIPPED` plus a warning listing the traits to add when a customized model lacks them.
+- **Team switch persistence**: `AuthController::switchTeam` now uses `forceFill(['current_team_id' => ...])->save()` instead of `update()`. `current_team_id` is a system-managed field deliberately kept out of the published User stub's `$fillable`, so the mass-assignment guard silently dropped it: the endpoint returned 200 "Team switched successfully" while `current_team_id` stayed null. Mirrors Jetstream's `switchTeam`. Regression test added with a fillable-restricted user fixture (the prior tests used a fully unguarded fixture and masked the bug).
 - **SwitchTeamRequest**: `team_id` validation rule now respects `magic-starter.use_uuids` config. When UUIDs are disabled (integer primary keys), the rule is `integer` instead of the previously hardcoded `uuid`, which caused a 422 on every team-switch attempt in integer-PK deployments.
 
 ### Changed

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -166,9 +166,8 @@ class InstallCommand extends Command
             $this->components->twoColumnDetail('Publishing policy stubs', '<fg=green;options=bold>DONE</>');
         }
 
-        // 10. Publish user model stub.
+        // 10. Publish user model stub (emits its own DONE / SKIPPED status).
         $this->publishUserModelStub();
-        $this->components->twoColumnDetail('Publishing user model stub', '<fg=green;options=bold>DONE</>');
 
         // 11. Publish language files.
         $this->publishLangFiles();
@@ -516,19 +515,104 @@ class InstallCommand extends Command
 
     /**
      * Publish the User model stub to App\Models.
+     *
+     * vendor:publish silently skips an existing target without --force, so a
+     * fresh Laravel app (which ships app/Models/User.php) would otherwise keep
+     * the default model with none of the Magic Starter traits while the
+     * installer still reported success. Mirror replaceDefaultUsersMigration:
+     * overwrite when the existing model is the stock Laravel default (or
+     * --force), preserve-and-warn when it has been customized.
      */
     private function publishUserModelStub(): void
     {
-        $publishOptions = [
+        $path = app_path('Models/User.php');
+
+        // No model yet: a plain publish lands the stub. Report DONE.
+        if (! file_exists($path)) {
+            $this->callSilently('vendor:publish', $this->userModelPublishOptions(false));
+            $this->components->twoColumnDetail('Publishing user model stub', '<fg=green;options=bold>DONE</>');
+
+            return;
+        }
+
+        // Already wired with the Magic Starter traits: leave any customizations
+        // intact (publish only on explicit --force).
+        if ($this->userModelHasMagicTraits($path)) {
+            if ((bool) $this->option('force')) {
+                $this->callSilently('vendor:publish', $this->userModelPublishOptions(true));
+            }
+            $this->components->twoColumnDetail('Publishing user model stub', '<fg=green;options=bold>DONE</>');
+
+            return;
+        }
+
+        // Existing model without the traits: overwrite when it is the stock
+        // Laravel default or --force was passed; otherwise preserve and warn.
+        if ((bool) $this->option('force') || $this->isDefaultLaravelUserModel($path)) {
+            $this->callSilently('vendor:publish', $this->userModelPublishOptions(true));
+            $this->components->twoColumnDetail('Publishing user model stub', '<fg=green;options=bold>DONE</>');
+
+            return;
+        }
+
+        $this->components->twoColumnDetail('Publishing user model stub', '<fg=yellow;options=bold>SKIPPED</>');
+        $this->components->warn('app/Models/User.php exists and is missing the required Magic Starter traits.');
+        $this->components->bulletList([
+            'Your customized model was preserved (stub NOT published).',
+            'Add manually: ConditionallyUsesUuids, HasApiTokens, HasGuestSupport, '
+                . 'HasNotifications, HasProfilePhoto, HasTeams, MustVerifyEmail, TwoFactorAuthenticatable.',
+            'Or re-run with --force to overwrite app/Models/User.php with the package stub.',
+        ]);
+    }
+
+    /**
+     * Build the vendor:publish options for the user model stub.
+     *
+     * @return array<string, mixed>
+     */
+    private function userModelPublishOptions(bool $force): array
+    {
+        $options = [
             '--provider' => MagicStarterServiceProvider::class,
             '--tag' => 'magic-starter-user-model',
         ];
 
-        if ((bool) $this->option('force')) {
-            $publishOptions['--force'] = true;
+        if ($force) {
+            $options['--force'] = true;
         }
 
-        $this->callSilently('vendor:publish', $publishOptions);
+        return $options;
+    }
+
+    /**
+     * Determine if the User model already uses the Magic Starter traits.
+     */
+    private function userModelHasMagicTraits(string $path): bool
+    {
+        $content = @file_get_contents($path);
+
+        return $content !== false
+            && str_contains($content, 'FlutterSdk\\MagicStarter\\Traits\\');
+    }
+
+    /**
+     * Determine if the User model is the unmodified Laravel default.
+     *
+     * Mirrors replaceDefaultUsersMigration's content-signature heuristic: the
+     * stock model extends Authenticatable and declares the default
+     * "use HasFactory, Notifiable;" trait line, with no Magic Starter traits.
+     */
+    private function isDefaultLaravelUserModel(string $path): bool
+    {
+        $content = @file_get_contents($path);
+
+        if ($content === false) {
+            return false;
+        }
+
+        return ! str_contains($content, 'FlutterSdk\\MagicStarter')
+            && str_contains($content, 'extends Authenticatable')
+            && str_contains($content, 'use HasFactory, Notifiable;');
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -535,9 +535,14 @@ class InstallCommand extends Command
             return;
         }
 
-        // Already wired with the Magic Starter traits: leave any customizations
-        // intact (publish only on explicit --force).
-        if ($this->userModelHasMagicTraits($path)) {
+        // Already wired with EVERY required Magic Starter trait: leave any
+        // customizations intact (publish only on explicit --force). A model
+        // carrying only SOME of the traits is NOT treated as compatible here;
+        // it falls through to the warning below so the operator learns which
+        // traits are still missing.
+        $missing = $this->missingUserTraits($path);
+
+        if ($missing === []) {
             if ((bool) $this->option('force')) {
                 $this->callSilently('vendor:publish', $this->userModelPublishOptions(true));
             }
@@ -546,8 +551,9 @@ class InstallCommand extends Command
             return;
         }
 
-        // Existing model without the traits: overwrite when it is the stock
-        // Laravel default or --force was passed; otherwise preserve and warn.
+        // Existing model missing one or more traits: overwrite when it is the
+        // stock Laravel default or --force was passed; otherwise preserve and
+        // warn, naming the specific traits that are absent.
         if ((bool) $this->option('force') || $this->isDefaultLaravelUserModel($path)) {
             $this->callSilently('vendor:publish', $this->userModelPublishOptions(true));
             $this->components->twoColumnDetail('Publishing user model stub', '<fg=green;options=bold>DONE</>');
@@ -556,11 +562,12 @@ class InstallCommand extends Command
         }
 
         $this->components->twoColumnDetail('Publishing user model stub', '<fg=yellow;options=bold>SKIPPED</>');
-        $this->components->warn('app/Models/User.php exists and is missing the required Magic Starter traits.');
+        $this->components->warn(
+            'app/Models/User.php is missing required Magic Starter traits: ' . implode(', ', $missing) . '.',
+        );
         $this->components->bulletList([
             'Your customized model was preserved (stub NOT published).',
-            'Add manually: ConditionallyUsesUuids, HasApiTokens, HasGuestSupport, '
-                . 'HasNotifications, HasProfilePhoto, HasTeams, MustVerifyEmail, TwoFactorAuthenticatable.',
+            'Add the missing traits manually (HasApiTokens from Laravel Sanctum is also required).',
             'Or re-run with --force to overwrite app/Models/User.php with the package stub.',
         ]);
     }
@@ -585,34 +592,76 @@ class InstallCommand extends Command
     }
 
     /**
-     * Determine if the User model already uses the Magic Starter traits.
+     * The Magic Starter traits the User model must carry for teams, 2FA,
+     * profile photos, notifications, guest auth, and UUID-optional keys to work.
+     *
+     * @var list<string>
      */
-    private function userModelHasMagicTraits(string $path): bool
+    private const REQUIRED_USER_TRAITS = [
+        'ConditionallyUsesUuids',
+        'HasGuestSupport',
+        'HasNotifications',
+        'HasProfilePhoto',
+        'HasTeams',
+        'TwoFactorAuthenticatable',
+    ];
+
+    /**
+     * Return the required Magic Starter traits NOT referenced by the User model.
+     *
+     * An empty result means the model is fully wired; a non-empty result (even
+     * a single entry) means the model is incomplete, so a partially-updated
+     * model is never mistaken for a compatible one. An unreadable file is
+     * treated as missing every trait.
+     *
+     * @return list<string>
+     */
+    private function missingUserTraits(string $path): array
     {
         $content = @file_get_contents($path);
 
-        return $content !== false
-            && str_contains($content, 'FlutterSdk\\MagicStarter\\Traits\\');
+        if ($content === false) {
+            return self::REQUIRED_USER_TRAITS;
+        }
+
+        return array_values(array_filter(
+            self::REQUIRED_USER_TRAITS,
+            static fn (string $trait): bool => ! str_contains($content, $trait),
+        ));
     }
 
     /**
      * Determine if the User model is the unmodified Laravel default.
      *
-     * Mirrors replaceDefaultUsersMigration's content-signature heuristic: the
-     * stock model extends Authenticatable and declares the default
-     * "use HasFactory, Notifiable;" trait line, with no Magic Starter traits.
+     * Tightened to require EVERY marker shared by the stock Laravel 11/12
+     * (property-based) and Laravel 13 (attribute-based) User models, so a
+     * customized model that has dropped or renamed any of them is not mistaken
+     * for the default and overwritten without --force. A model referencing the
+     * Magic Starter namespace is never the stock default.
      */
     private function isDefaultLaravelUserModel(string $path): bool
     {
         $content = @file_get_contents($path);
 
-        if ($content === false) {
+        if ($content === false || str_contains($content, 'FlutterSdk\\MagicStarter')) {
             return false;
         }
 
-        return ! str_contains($content, 'FlutterSdk\\MagicStarter')
-            && str_contains($content, 'extends Authenticatable')
-            && str_contains($content, 'use HasFactory, Notifiable;');
+        $stockMarkers = [
+            'class User extends Authenticatable',
+            'use HasFactory, Notifiable;',
+            'use Illuminate\\Foundation\\Auth\\User as Authenticatable;',
+            'use Illuminate\\Notifications\\Notifiable;',
+            'use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;',
+        ];
+
+        foreach ($stockMarkers as $marker) {
+            if (! str_contains($content, $marker)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -196,9 +196,12 @@ class AuthController
             ], 403);
         }
 
-        $user->update([
+        // current_team_id is a system-managed field deliberately kept out of
+        // the User model's $fillable; forceFill persists it regardless of the
+        // consumer model's mass-assignment guard (mirrors Jetstream switchTeam).
+        $user->forceFill([
             'current_team_id' => $teamId,
-        ]);
+        ])->save();
 
         return response()->json([
             'data' => new UserResource($request->user()->fresh()),

--- a/tests/Console/InstallCommandTest.php
+++ b/tests/Console/InstallCommandTest.php
@@ -331,6 +331,51 @@ final class InstallCommandTest extends TestCase
         );
     }
 
+    public function test_install_overwrites_stock_default_user_model(): void
+    {
+        // Regression: vendor:publish silently skips an existing target without
+        // --force, so a fresh Laravel app kept the default User model with none
+        // of the Magic Starter traits while the installer reported DONE.
+        File::ensureDirectoryExists(app_path('Models'));
+        File::put(app_path('Models/User.php'), $this->stockLaravelUserModel());
+
+        $this->artisan('magic-starter:install')->assertExitCode(0);
+
+        $this->assertStringContainsString(
+            'ConditionallyUsesUuids',
+            File::get(app_path('Models/User.php')),
+            'Stock default User model should be overwritten with the trait-laden stub.',
+        );
+    }
+
+    public function test_install_preserves_customized_user_model_without_force(): void
+    {
+        File::ensureDirectoryExists(app_path('Models'));
+        $customized = "<?php\n\nnamespace App\\Models;\n\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
+            . "class User extends Authenticatable\n{\n    public \$customMarker = true;\n}\n";
+        File::put(app_path('Models/User.php'), $customized);
+
+        $this->artisan('magic-starter:install')->assertExitCode(0);
+
+        // Customized model preserved, NOT silently overwritten.
+        $this->assertStringContainsString('customMarker', File::get(app_path('Models/User.php')));
+        $this->assertStringNotContainsString('ConditionallyUsesUuids', File::get(app_path('Models/User.php')));
+    }
+
+    public function test_install_force_overwrites_customized_user_model(): void
+    {
+        File::ensureDirectoryExists(app_path('Models'));
+        $customized = "<?php\n\nnamespace App\\Models;\n\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
+            . "class User extends Authenticatable\n{\n    public \$customMarker = true;\n}\n";
+        File::put(app_path('Models/User.php'), $customized);
+
+        $this->artisan('magic-starter:install', ['--force' => true])->assertExitCode(0);
+
+        $this->assertStringContainsString('ConditionallyUsesUuids', File::get(app_path('Models/User.php')));
+    }
+
     public function test_install_publishes_team_policy_when_teams_selected(): void
     {
         $this->artisan('magic-starter:install', [
@@ -399,6 +444,21 @@ final class InstallCommandTest extends TestCase
 
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * The stock Laravel default User model content (signature the installer
+     * recognises as safe to overwrite).
+     */
+    private function stockLaravelUserModel(): string
+    {
+        return "<?php\n\nnamespace App\\Models;\n\n"
+            . "use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n"
+            . "use Illuminate\\Notifications\\Notifiable;\n\n"
+            . "class User extends Authenticatable\n{\n"
+            . "    use HasFactory, Notifiable;\n\n"
+            . "    protected \$fillable = ['name', 'email', 'password'];\n}\n";
+    }
 
     private function cleanupPublishedArtifacts(): void
     {

--- a/tests/Console/InstallCommandTest.php
+++ b/tests/Console/InstallCommandTest.php
@@ -348,6 +348,43 @@ final class InstallCommandTest extends TestCase
         );
     }
 
+    public function test_install_preserves_an_already_trait_equipped_user_model(): void
+    {
+        // A model that already uses the Magic Starter traits is left intact
+        // (no overwrite, no warning) so consumer customizations survive re-runs.
+        File::ensureDirectoryExists(app_path('Models'));
+        $equipped = "<?php\n\nnamespace App\\Models;\n\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasTeams;\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
+            . "class User extends Authenticatable\n{\n    use HasTeams;\n"
+            . "    public \$customMarker = true;\n}\n";
+        File::put(app_path('Models/User.php'), $equipped);
+
+        $this->artisan('magic-starter:install')->assertExitCode(0);
+
+        $contents = File::get(app_path('Models/User.php'));
+        $this->assertStringContainsString('customMarker', $contents);
+        $this->assertStringContainsString('HasTeams', $contents);
+    }
+
+    public function test_install_force_republishes_trait_equipped_user_model(): void
+    {
+        File::ensureDirectoryExists(app_path('Models'));
+        $equipped = "<?php\n\nnamespace App\\Models;\n\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasTeams;\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
+            . "class User extends Authenticatable\n{\n    use HasTeams;\n"
+            . "    public \$customMarker = true;\n}\n";
+        File::put(app_path('Models/User.php'), $equipped);
+
+        $this->artisan('magic-starter:install', ['--force' => true])->assertExitCode(0);
+
+        // --force re-publishes the package stub, dropping the custom marker.
+        $contents = File::get(app_path('Models/User.php'));
+        $this->assertStringContainsString('ConditionallyUsesUuids', $contents);
+        $this->assertStringNotContainsString('customMarker', $contents);
+    }
+
     public function test_install_preserves_customized_user_model_without_force(): void
     {
         File::ensureDirectoryExists(app_path('Models'));

--- a/tests/Console/InstallCommandTest.php
+++ b/tests/Console/InstallCommandTest.php
@@ -348,17 +348,12 @@ final class InstallCommandTest extends TestCase
         );
     }
 
-    public function test_install_preserves_an_already_trait_equipped_user_model(): void
+    public function test_install_preserves_a_fully_trait_equipped_user_model(): void
     {
-        // A model that already uses the Magic Starter traits is left intact
+        // A model that already carries EVERY required trait is left intact
         // (no overwrite, no warning) so consumer customizations survive re-runs.
         File::ensureDirectoryExists(app_path('Models'));
-        $equipped = "<?php\n\nnamespace App\\Models;\n\n"
-            . "use FlutterSdk\\MagicStarter\\Traits\\HasTeams;\n"
-            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
-            . "class User extends Authenticatable\n{\n    use HasTeams;\n"
-            . "    public \$customMarker = true;\n}\n";
-        File::put(app_path('Models/User.php'), $equipped);
+        File::put(app_path('Models/User.php'), $this->fullyWiredUserModel());
 
         $this->artisan('magic-starter:install')->assertExitCode(0);
 
@@ -367,15 +362,33 @@ final class InstallCommandTest extends TestCase
         $this->assertStringContainsString('HasTeams', $contents);
     }
 
-    public function test_install_force_republishes_trait_equipped_user_model(): void
+    public function test_install_warns_when_user_model_has_only_some_traits(): void
     {
+        // A partially-updated model (some traits, not all) must NOT be treated
+        // as compatible: it is preserved AND the operator is told which traits
+        // are still missing, instead of a silent skip.
         File::ensureDirectoryExists(app_path('Models'));
-        $equipped = "<?php\n\nnamespace App\\Models;\n\n"
+        $partial = "<?php\n\nnamespace App\\Models;\n\n"
             . "use FlutterSdk\\MagicStarter\\Traits\\HasTeams;\n"
             . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
             . "class User extends Authenticatable\n{\n    use HasTeams;\n"
             . "    public \$customMarker = true;\n}\n";
-        File::put(app_path('Models/User.php'), $equipped);
+        File::put(app_path('Models/User.php'), $partial);
+
+        $this->artisan('magic-starter:install')
+            ->expectsOutputToContain('missing required Magic Starter traits')
+            ->assertExitCode(0);
+
+        // Preserved (not overwritten), and the missing-trait warning fired.
+        $contents = File::get(app_path('Models/User.php'));
+        $this->assertStringContainsString('customMarker', $contents);
+        $this->assertStringNotContainsString('ConditionallyUsesUuids', $contents);
+    }
+
+    public function test_install_force_republishes_fully_trait_equipped_user_model(): void
+    {
+        File::ensureDirectoryExists(app_path('Models'));
+        File::put(app_path('Models/User.php'), $this->fullyWiredUserModel());
 
         $this->artisan('magic-starter:install', ['--force' => true])->assertExitCode(0);
 
@@ -486,6 +499,27 @@ final class InstallCommandTest extends TestCase
      * The stock Laravel default User model content (signature the installer
      * recognises as safe to overwrite).
      */
+    /**
+     * A User model that already carries every required Magic Starter trait
+     * plus a custom marker (to assert it is preserved, not overwritten).
+     */
+    private function fullyWiredUserModel(): string
+    {
+        return "<?php\n\nnamespace App\\Models;\n\n"
+            . "use FlutterSdk\\MagicStarter\\Support\\ConditionallyUsesUuids;\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasGuestSupport;\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasNotifications;\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasProfilePhoto;\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\HasTeams;\n"
+            . "use FlutterSdk\\MagicStarter\\Traits\\TwoFactorAuthenticatable;\n"
+            . "use Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\n"
+            . "class User extends Authenticatable\n{\n"
+            . "    use ConditionallyUsesUuids;\n    use HasGuestSupport;\n"
+            . "    use HasNotifications;\n    use HasProfilePhoto;\n"
+            . "    use HasTeams;\n    use TwoFactorAuthenticatable;\n\n"
+            . "    public \$customMarker = true;\n}\n";
+    }
+
     private function stockLaravelUserModel(): string
     {
         return "<?php\n\nnamespace App\\Models;\n\n"

--- a/tests/Http/Controllers/AuthControllerTest.php
+++ b/tests/Http/Controllers/AuthControllerTest.php
@@ -426,6 +426,39 @@ class AuthControllerTest extends TestCase
             ->assertJsonPath('message', 'This action is unauthorized.');
     }
 
+    public function test_switch_team_persists_when_user_model_guards_current_team_id(): void
+    {
+        // Regression: the published User stub lists an explicit $fillable that
+        // omits current_team_id (a system-managed field). A mass-assignment
+        // update() silently drops it, so the switch returned 200 but never
+        // persisted. This fixture mirrors that guard; switchTeam must forceFill.
+        $user = AuthControllerGuardedUser::query()->create([
+            'name' => 'Guarded User',
+            'email' => 'guarded@example.com',
+            'password' => Hash::make('Password123'),
+            'locale' => 'en',
+            'timezone' => 'UTC',
+        ]);
+
+        $team = AuthControllerTestTeam::query()->create([
+            'id' => (string) Str::uuid(),
+            'user_id' => $user->id,
+            'name' => 'Guarded Team',
+            'personal_team' => false,
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/switch-team', [
+            'team_id' => $team->id,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('message', 'Team switched successfully')
+            ->assertJsonPath('data.current_team.id', $team->id);
+
+        $this->assertSame($team->id, $user->fresh()->current_team_id);
+    }
+
     public function test_login_returns_401_for_wrong_password(): void
     {
         AuthControllerTestUser::query()->create([
@@ -575,6 +608,33 @@ final class AuthControllerTestUser extends Model implements AuthenticatableContr
     {
         return $this->currentAccessTokenStub;
     }
+}
+
+final class AuthControllerGuardedUser extends Model implements AuthenticatableContract
+{
+    use AuthenticatableTrait;
+    use Authorizable;
+    use \FlutterSdk\MagicStarter\Traits\HasProfilePhoto;
+    use \FlutterSdk\MagicStarter\Traits\HasTeams;
+    use HasUuids;
+
+    protected $table = 'users';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    // Mirrors the published User stub: current_team_id is intentionally absent,
+    // so a plain mass-assignment update() cannot persist it.
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'phone',
+        'phone_country',
+        'locale',
+        'timezone',
+    ];
 }
 
 final class AuthControllerTestTeam extends \FlutterSdk\MagicStarter\Models\Team


### PR DESCRIPTION
## Summary
Two out-of-box correctness fixes surfaced by a from-scratch install QA (fresh Laravel app, integer primary keys).

### Team switch never persisted (#B)
`AuthController::switchTeam` used `$user->update(['current_team_id' => ...])`. `current_team_id` is a system-managed field deliberately kept out of the published User stub's `$fillable`, so the mass-assignment guard silently dropped it: the endpoint returned **200 'Team switched successfully'** while `current_team_id` stayed **null**. The existing test used a fully unguarded fixture and masked the bug.

- Fix: `forceFill(['current_team_id' => ...])->save()` (mirrors Jetstream `switchTeam`).
- Regression test `test_switch_team_persists_when_user_model_guards_current_team_id` with a fillable-restricted fixture (red before, green after).

### User model stub silently skipped on a fresh app (#A)
`magic-starter:install` published the trait-laden `app/Models/User.php` stub via `vendor:publish` **without `--force`**, which silently skips an existing target. On a fresh Laravel app the default model was kept with none of the Magic Starter traits (HasTeams, TwoFactorAuthenticatable, ...) while the installer printed **DONE**, leaving teams/2FA/profile endpoints broken with no warning.

- Fix: mirror the default-users-migration heuristic. Overwrite the stock Laravel default (or `--force`), preserve a trait-equipped/customized model, print `SKIPPED` + a warning listing the traits when a customized model lacks them.
- 3 regression tests (stock default overwritten, customized preserved without force, `--force` overwrites customized).

## Verification
- `vendor/bin/phpunit`: **546 tests green**.
- `vendor/bin/pint --test`: clean.
- Out-of-box re-verify on a fresh app: `magic-starter:install` (no `--force`) -> User.php has all 7 traits; team switch persists `current_team_id`.

Author: Anılcan Çakır <anilcan.cakir@gmail.com>